### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/musicruntime/musicqueueviewer/mqv_datasource.py
+++ b/musicruntime/musicqueueviewer/mqv_datasource.py
@@ -76,7 +76,7 @@ except NameError:
 		def reloadTable(self):
 			self.tableView.reloadData()
 
-			if self.tableView.numberOfRowsInSection(0) is not 0:
+			if self.tableView.numberOfRowsInSection(0) != 0:
 				indexZero = objc.ObjCClass("NSIndexPath").indexPathForRow(0, inSection=0)
 				self.tableView.scrollToRowAtIndexPath(indexZero, atScrollPosition=1, animated=True)
 				pass


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% python3.8
```
>>> 0 is 0
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```